### PR TITLE
Simplify the CI matrix config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,51 +11,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - version: '1.6'
-            os: ubuntu-latest
-            arch: x64
-          - version: '1.6'
-            os: macOS-latest
-            arch: x64
-          - version: '1.6'
-            os: windows-latest
-            arch: x64
-          - version: '1.6'
-            os: ubuntu-latest
-            arch: x86
-          - version: '1.6'
-            os: windows-latest
-            arch: x86
-          - version: '1'
-            os: ubuntu-latest
-            arch: x64
-          - version: '1'
-            os: macOS-latest
-            arch: x64
-          - version: '1'
-            os: windows-latest
-            arch: x64
-          - version: '1'
-            os: ubuntu-latest
-            arch: x86
-          - version: '1'
-            os: windows-latest
-            arch: x86
-          - version: 'nightly'
-            os: ubuntu-latest
-            arch: x64
-          - version: 'nightly'
-            os: macOS-latest
-            arch: x64
-          - version: 'nightly'
-            os: windows-latest
-            arch: x64
-          - version: 'nightly'
-            os: ubuntu-latest
-            arch: x86
-          - version: 'nightly'
-            os: windows-latest
+        version: ['1.6', '1', 'nightly']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        arch: [x64, x86]
+        exclude:
+          - os: macOS-latest
             arch: x86
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Make use of the matrix functionality to simplify how we write the tests to run in the CI.