### PR TITLE
Fix unsafe_load of uninitialized workspace

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -738,10 +738,10 @@ end
 Obtain problem dimensions from OSQP model
 """
 function dimensions(model::OSQP.Model)
-    workspace = unsafe_load(model.workspace)
-    if workspace == C_NULL
+    if model.workspace == C_NULL
         error("Workspace has not been setup yet")
     end
+    workspace = unsafe_load(model.workspace)
     data = unsafe_load(workspace.data)
     return data.n, data.m
 end


### PR DESCRIPTION
It's never safe to call `unsafe_load` when the pointer is not explicitly initialized

```julia
julia> import OSQP

julia> p = Ptr{OSQP.Workspace}(C_NULL)
Ptr{OSQP.Workspace} @0x0000000000000000

julia> unsafe_load(p)

[87795] signal (11.1): Segmentation fault: 11
in expression starting at REPL[3]:1
unsafe_load at ./pointer.jl:119 [inlined]
unsafe_load at ./pointer.jl:119
unknown function (ip: 0x10c832567)
```